### PR TITLE
Ignore VS Code temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Ignore VS Code temporary files
+.vscode

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,0 @@
-{
-    "recommendations": [
-        "github.copilot-chat"
-    ]
-}


### PR DESCRIPTION
This pull request contains a commit that removes the `.vscode` folder from the project's root, while adding a line to the `.gitignore` file to ignore future occasions where this folder may appear.