### PR TITLE
Perform CI tests with Python 3.12

### DIFF
--- a/.github/workflows/cov.yml
+++ b/.github/workflows/cov.yml
@@ -3,10 +3,10 @@ name: Coverage
 on:
   pull_request:
     branches: [main]
-    paths: [ 'agenet/**', 'tests/**', '.github/workflows/cov.yml', '.github/workflows/**' ]
+    paths: [ 'agenet/**', 'tests/**', '.github/workflows/cov.yml' ]
   push:
     branches: [main]
-    paths: [ 'agenet/**', 'tests/**', '.github/workflows/cov.yml', '.github/workflows/**']
+    paths: [ 'agenet/**', 'tests/**', '.github/workflows/cov.yml' ]
     tags: '*'
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
         pip install pip --upgrade
         pip install .[dev]
     - name: Test with pytest and create coverage report
-      run: pytest --cov=agenet --cov-report=xml 
+      run: pytest --cov=agenet --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,10 @@ name: Tests
 on:
   pull_request:
     branches: [main]
-    paths: [ 'agenet/**', 'tests/**', 'pyproject.toml' ]
+    paths: [ 'agenet/**', 'tests/**', 'pyproject.toml', '.github/workflows/test.yml' ]
   push:
     branches: [main]
-    paths: [ 'agenet/**', 'tests/**', 'pyproject.toml' ]
+    paths: [ 'agenet/**', 'tests/**', 'pyproject.toml', '.github/workflows/test.yml' ]
     tags: '*'
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['3.8', '3.11']
+        version: ['3.8', '3.12']
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - name: Clone repository


### PR DESCRIPTION
Python 3.12 has been recently released. This pull request updates the `test` CI action to test with Python 3.12 instead of 3.11. Wait for the automatic tests to finish before accepting the pull request, so we're sure that everything works properly with this new Python version.