### PR TITLE
Check for invalid active_prob value

### DIFF
--- a/agenet/maincom.py
+++ b/agenet/maincom.py
@@ -39,9 +39,21 @@ def simulation(
     Returns:
        Theoretical AAoI and simulation AAoI.
     """
-    # Check parameters
-    if active_prob < 0 or active_prob > 1:
+    # Input validation
+    if not 0 <= active_prob <= 1:
         raise ValueError("active_prob must be between 0 and 1")
+    if n <= 0:
+        raise ValueError("n must be greater than 0")
+    if k <= 0:
+        raise ValueError("k must be greater than 0")
+    if k > n:
+        raise ValueError("k must be less than or equal to n")
+    if P <= 0:
+        raise ValueError("P must be greater than 0")
+    if N0 <= 0:
+        raise ValueError("N0 must be greater than 0")
+    if fr <= 0:
+        raise ValueError("fr must be greater than 0")
 
     # Initialize PCG64 generator
     rng = Generator(PCG64(seed))
@@ -117,14 +129,14 @@ def simulation(
     else:
         t1 = [0] + sermat
 
-    system_time = 1 / lambda1  # system time (time which update in the system)
-    av_age_simulation, _, _ = av_age_fn(v1, t1, system_time)
-
     # Handle the case where er_p_th is very close to or equal to 1
     if abs(1 - er_p_th) < 1e-10:  # Choose a small threshold
-        av_age_theoretical = float("inf")
-    else:
-        av_age_theoretical = (1 / lambda1) * (0.5 + (1 / (1 - er_p_th)))
+        return float('inf'), float('inf')
+
+    av_age_theoretical = (1 / lambda1) * (0.5 + (1 / (1 - er_p_th)))
+
+    system_time = 1 / lambda1  # system time (time which update in the system)
+    av_age_simulation, _, _ = av_age_fn(v1, t1, system_time)
 
     return av_age_theoretical, av_age_simulation
 
@@ -170,10 +182,7 @@ def run_simulation(
             num_nodes, active_prob, n, k, P, d, N0, fr, numevnts, seed=run_seed
         )
         if np.isinf(av_age_theoretical_i):
-            return (
-                float("inf"),
-                av_age_simulation_i,
-            )  # Return immediately if theoretical value is infinity
+            return float('inf'), float('inf')  # Return infinity for both if theoretical is infinity
         av_age_theoretical_run += av_age_theoretical_i
         av_age_simulation_run += av_age_simulation_i
     av_age_theoretical_run /= num_runs

--- a/agenet/maincom.py
+++ b/agenet/maincom.py
@@ -39,6 +39,10 @@ def simulation(
     Returns:
        Theoretical AAoI and simulation AAoI.
     """
+    # Check parameters
+    if active_prob < 0 or active_prob > 1:
+        raise ValueError("active_prob must be between 0 and 1")
+
     # Initialize PCG64 generator
     rng = Generator(PCG64(seed))
 


### PR DESCRIPTION
In the simulation() function we were not checking for an invalid active_prob parameter. This pull request adds that check.